### PR TITLE
Regression test for Issue 61

### DIFF
--- a/src/views/About.js
+++ b/src/views/About.js
@@ -1,45 +1,8 @@
-/*!
-
-=========================================================
-* Argon Design System React - v1.1.0
-=========================================================
-
-* Product Page: https://www.creative-tim.com/product/argon-design-system-react
-* Copyright 2020 Creative Tim (https://www.creative-tim.com)
-* Licensed under MIT (https://github.com/creativetimofficial/argon-design-system-react/blob/master/LICENSE.md)
-
-* Coded by Creative Tim
-
-=========================================================
-
-* The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-*/
-import React, {useState} from "react";
-// nodejs library that concatenates classes
-import classnames from "classnames";
-
-// reactstrap components
-import {
-  Badge,
-  Button,
-  Card,
-  CardBody,
-  CardImg,
-  FormGroup,
-  Input,
-  InputGroupAddon,
-  InputGroupText,
-  InputGroup,
-  Container,
-  Row,
-  Col
-} from "reactstrap";
+import React from "react";
+import { Row, Col } from "reactstrap";
 
 // core components
 import PageNavbar from "components/Navbars/PageNavbar.js";
-import DonateForm from "components/DonateForm.js";
-import RequestForm from "components/RequestForm.js";
 import Hero from "components/Hero.js";
 import Profile from "components/Profile.js";
 import SimpleFooter from "components/SimpleFooter.js";
@@ -63,24 +26,27 @@ import Kanbanize from "assets/img/sponsors/kanbanize.svg";
 import CanRedCross from "assets/img/sponsors/canredcross.png";
 import HealthCanada from "assets/img/sponsors/healthcanada.png";
 
-
 const AboutPage = () => {
   return (
     <>
-    <PageNavbar/>
+      <PageNavbar />
       <Hero
         heading="About us"
-        body="Meet our volunteers, sponsors, and partners."/>
+        body="Meet our volunteers, sponsors, and partners."
+      />
       <Row className="d-flex justify-content-center text-center no-margin about">
         <Col xs={6}>
-          <p>We're a bunch of cool people on a mission to help make masks more accessible using the power of Open Source.</p>
+          <p>
+            We're a bunch of cool people on a mission to help make masks more
+            accessible using the power of Open Source.
+          </p>
         </Col>
       </Row>
-    <Row id="profiles">
-      <Profile
-        name="Mekki MacAulay"
-        role="Executive Director & Chair of the Board of Directors - Evidence-Based Social Enterprises Canada"
-        description="Mekki MacAulay is the Founder of Evidence-Based Social Enterprises Canada, a charitable organization whose mission is to \
+      <Row id="profiles">
+        <Profile
+          name="Mekki MacAulay"
+          role="Executive Director & Chair of the Board of Directors - Evidence-Based Social Enterprises Canada"
+          description="Mekki MacAulay is the Founder of Evidence-Based Social Enterprises Canada, a charitable organization whose mission is to \
 apply evidence-based policy approaches to help the most vulnerable in our society who fall through the cracks of existing government and other social support systems. \
 He launched the Donate A Mask Canada Project because he saw people frustrated and scared that they were unable to protect themselves and their loved ones with high-quality \
 masks during the COVID-19 pandemic and resolved to put his talents as a Professional Engineer (PEng) and Strategic Management PhD to use to tackle that problem head on, bringing \
@@ -89,96 +55,78 @@ people how to care about one another is to show them, with action.  His social e
 the many projects of the broader open source and free software movements, and animal support charity organisations like the Toronto Humane Society, Toronto Street Cats, \
 and Toronto Cat Rescue, with whom he has worked as a volunteer for many years. \
 Mekki currently lives in Toronto and works at IBM as Financial Services Sector Lead in IBM Consulting Canada's Red Hat Practice GTM."
-        avatar={Mekki}
-        linkedin="https://www.linkedin.com/in/mekkim"
-        twitter="https://twitter.com/mekki"
-        email="mekki@donatemask.ca"
+          avatar={Mekki}
+          linkedin="https://www.linkedin.com/in/mekkim"
+          twitter="https://twitter.com/mekki"
+          email="mekki@donatemask.ca"
         />
-      <Profile
-      name="Haider Zaidi"
-      role="Software Developer, Second-Year Undergrad at the Schulich School of Business"
-      avatar={Haider}
-      linkedin="https://www.linkedin.com/in/haider-zaidi/"
-      website="https://haiderzaidi.ca"
-      email="haider@donatemask.ca"
-      />
-      <Profile
-      name="David Izrailov"
-      role="Data & Marketing, Second-Year Undergrad at the Schulich School of Business"
-      avatar={David}
-      linkedin="https://www.linkedin.com/in/david-izrailov/"
-      website="http://davidizrailov.com"
-      email="david@donatemask.ca"
-      />
-      <Profile
-      name="Chris Ring"
-      role="Business and Digital Transformation Strategist, Agile Leader"
-      avatar={Chris}
-      linkedin="https://www.linkedin.com/in/chrisjring/"
-      website="https://www.linkedin.com/in/chrisjring/"
-      email="chris@donatemask.ca"
-      />
-      <Profile
-      name="Devarsh Patel"
-      role="Associate Software Developer"
-      avatar={Devarsh}
-      linkedin="https://www.linkedin.com/in/devarsh19/"
-      website="https://github.com/devarsh19"
-      email="devarsh@donatemask.ca"
-      />
-      <Profile
-      name="Sarah Guimond"
-      role="Program Manager"
-      avatar={Sarah}
-      linkedin="https://www.linkedin.com/in/sarahguimond/"
-      twitter="https://twitter.com/sarah_guimond_"
-      email="sarah@donatemask.ca"
-      />
-    </Row>
-		  <Row className="d-flex justify-content-center text-center no-margin about">
-				<Col xs={6}>
-					<h1>Sponsors & Partners</h1>
-				</Col>
-			</Row>
+        <Profile
+          name="Haider Zaidi"
+          role="Software Developer, Second-Year Undergrad at the Schulich School of Business"
+          avatar={Haider}
+          linkedin="https://www.linkedin.com/in/haider-zaidi/"
+          website="https://haiderzaidi.ca"
+          email="haider@donatemask.ca"
+        />
+        <Profile
+          name="David Izrailov"
+          role="Data & Marketing, Second-Year Undergrad at the Schulich School of Business"
+          avatar={David}
+          linkedin="https://www.linkedin.com/in/david-izrailov/"
+          website="http://davidizrailov.com"
+          email="david@donatemask.ca"
+        />
+        <Profile
+          name="Chris Ring"
+          role="Business and Digital Transformation Strategist, Agile Leader"
+          avatar={Chris}
+          linkedin="https://www.linkedin.com/in/chrisjring/"
+          website="https://www.linkedin.com/in/chrisjring/"
+          email="chris@donatemask.ca"
+        />
+        <Profile
+          name="Devarsh Patel"
+          role="Associate Software Developer"
+          avatar={Devarsh}
+          linkedin="https://www.linkedin.com/in/devarsh19/"
+          website="https://github.com/devarsh19"
+          email="devarsh@donatemask.ca"
+        />
+        <Profile
+          name="Sarah Guimond"
+          role="Program Manager"
+          avatar={Sarah}
+          linkedin="https://www.linkedin.com/in/sarahguimond/"
+          twitter="https://twitter.com/sarah_guimond_"
+          email="sarah@donatemask.ca"
+        />
+      </Row>
+      <Row className="d-flex justify-content-center text-center no-margin about">
+        <Col xs={6}>
+          <h2>Sponsors & Partners</h2>
+        </Col>
+      </Row>
 
-			<Row id="sponsors" className="d-flex flex-wrap align-items-center">
-				<Sponsorship
-					src={Desjardins}
-					padding="10px"
-					href="https://www.desjardins.com/ca/"
-				/>
-				<Sponsorship
-					src={Eclipse}
-					href="https://www.eclipseinnovations.com/"
-				/>
-				<Sponsorship
-					src= {Vitacore}
-					href="https://www.vitacore.ca/"
-				/>
-				<Sponsorship
-					src={TTC}
-					href="https://www.ttc.ca/"
-				/>
-				<Sponsorship
-					src={FDK}
-					href="https://www.fdksupply.com/"
-				/>
-				<Sponsorship
-					src={Kanbanize}
-					href="https://kanbanize.com/"
-				/>
-				<Sponsorship
-					src={CanRedCross}
-					href="https://www.redcross.ca/"
-				/>
-				<Sponsorship
-					src={HealthCanada}
-					href="https://www.canada.ca/en/health-canada.html"
-				/>
-			</Row>
-    <SimpleFooter/>
+      <Row id="sponsors" className="d-flex flex-wrap align-items-center">
+        <Sponsorship
+          src={Desjardins}
+          padding="10px"
+          href="https://www.desjardins.com/ca/"
+        />
+        <Sponsorship src={Eclipse} href="https://www.eclipseinnovations.com/" />
+        <Sponsorship src={Vitacore} href="https://www.vitacore.ca/" />
+        <Sponsorship src={TTC} href="https://www.ttc.ca/" />
+        <Sponsorship src={FDK} href="https://www.fdksupply.com/" />
+        <Sponsorship src={Kanbanize} href="https://kanbanize.com/" />
+        <Sponsorship src={CanRedCross} href="https://www.redcross.ca/" />
+        <Sponsorship
+          src={HealthCanada}
+          href="https://www.canada.ca/en/health-canada.html"
+        />
+      </Row>
+      <SimpleFooter />
     </>
   );
-}
+};
 
 export default AboutPage;

--- a/test/integration/issue-61.test.js
+++ b/test/integration/issue-61.test.js
@@ -1,0 +1,34 @@
+// Regression test for https://github.com/EBSECan/donatemask/issues/61
+// Direct linking to a route should render the expected SPA route and page.
+
+const { test, expect } = require("@playwright/test");
+
+const confirmRoute = async (page, route, text) => {
+  await page.goto(`http://localhost:4443${route}`);
+  const title = page.locator("h1");
+  await expect(title).toHaveText(text);
+};
+
+test("Donate page loads with direct link to /donate route", async ({ page }) =>
+  confirmRoute(page, "/donate", "Donate a mask"));
+
+test("Request page loads with direct link to /request route", async ({ page }) =>
+  confirmRoute(page, "/request", "Request masks and boxes of COVID rapid tests"));
+
+test("Buy page loads with direct link to /buy route", async ({ page }) => 
+  confirmRoute(page, "/buy", "Buy disposable masks and respirator kits from our charity store"));
+
+test("Summary page loads with direct link to /summary route", async ({ page }) =>
+  confirmRoute(page, '/summary', "Summary"))
+
+test("About page loads with direct link to /about route", async ({ page }) =>
+  confirmRoute(page, '/about', "About us"));
+
+test("FAQ page loads with direct link to /faq route", async ({ page }) =>
+  confirmRoute(page, '/faq', "Frequently asked questions"));
+
+test("Privacy page loads with direct link to /privacy route", async ({ page }) =>
+  confirmRoute(page, '/privacy', "Privacy policy"));
+
+test("Terms page loads with direct link to /terms route", async ({ page }) =>
+  confirmRoute(page, '/terms', "Terms"));


### PR DESCRIPTION
This adds a regression test for #61, which I (re)broke with some recent refactoring.  These tests will check to make sure that the routes produce the expected page, as judged by the value of the `<h1>` element on each of the pages.  If we update the wording, we'll have to update these tests to match.

They will run on every push to `main` as part of the integration tests.

While I was fixing this, the About page was failing, due to it using multiple `<h1>` elements (only 1 per page is allowed in HTML5).  I've switched to an `<h2>` for the second, and reformatted the code at the same time, removing some unnecessary imports.