### PR TITLE
Force a refresh on router changes (e.g., scroll to top)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ import Terms from "views/Terms.js";
 import ConfirmRequest from "views/ConfirmRequest.js";
 
 ReactDOM.render(
-  <BrowserRouter>
+  <BrowserRouter forceRefresh>
     <Switch>
       <Route path="/" exact render={(props) => <Landing {...props} />} />
       <Route path="/donate" exact render={(props) => <Donate {...props} />} />


### PR DESCRIPTION
We have a bug where the scroll position from one route is inherited in another when you navigate.  For example:

- go to the Donate page
- scroll to the bottom and click on the link to the Store
- notice that you're not at the top of the store

This fix forces a refresh of the page so that the position gets reset.  It also allows you to navigate to the current page, which is broken in mobile at the moment.

See https://v5.reactrouter.com/web/api/BrowserRouter/forcerefresh-bool.