### PR TITLE
Demographics collection backend changes with tests

### DIFF
--- a/server/db/demographics.js
+++ b/server/db/demographics.js
@@ -1,0 +1,41 @@
+const dbo = require("./conn");
+
+/**
+ * Demographics Schema:
+ *
+ * _id: "61e86ee591676123aaab97d1"
+ * groups: ["People with low income", "Children/youth", ...] | ["None Selected"]
+ * timestamp: "2022-01-19T20:04:52.611Z"
+ *
+ * See const.js for current list of demographic groups.
+ */
+
+module.exports.get = () => {
+  const db = dbo.getDb();
+  return db.collection("demographics").find({}).toArray();
+};
+
+module.exports.add = (data) => {
+  const db = dbo.getDb();
+  return db.collection("demographics").insertOne(data);
+};
+
+module.exports.stats = async () => {
+  const db = dbo.getDb();
+  const demographics = await db.collection("demographics").find({}).toArray();
+
+  // Go through all records, and all groups in those records,
+  // and count how many times we encounter each one.
+  const groupCounts = {};
+  demographics.forEach(({ groups }) => {
+    groups.forEach((group) => {
+      groupCounts[group] = groupCounts[group] || 0;
+      groupCounts[group] = groupCounts[group] + 1;
+    });
+  });
+
+  return {
+    count: demographics.length,
+    groupCounts,
+  };
+};

--- a/server/db/mask-requests.js
+++ b/server/db/mask-requests.js
@@ -1,5 +1,5 @@
 const dbo = require("./conn");
-const { toInt } = require('../util');
+const { toInt } = require("../util");
 
 /**
  * Mask Request Schema:
@@ -60,7 +60,8 @@ module.exports.stats = async () => {
   let testsRequested = 0;
   let testsFulfilled = 0;
 
-   maskRequests.forEach(({ testAmnt, requestFulfilled, maskAmnt, maskAmntSmall, maskAmntRegular }) => {
+  maskRequests.forEach(
+    ({ testAmnt, requestFulfilled, maskAmntSmall, maskAmntRegular }) => {
       testsRequested += toInt(testAmnt);
       masksRequested += toInt(maskAmntSmall) + toInt(maskAmntRegular);
 
@@ -68,7 +69,8 @@ module.exports.stats = async () => {
         testsFulfilled += toInt(testAmnt);
         masksFulfilled += toInt(maskAmntSmall) + toInt(maskAmntRegular);
       }
-    });
+    }
+  );
 
   return {
     masksRequested,

--- a/test/server/db/demographics.test.js
+++ b/test/server/db/demographics.test.js
@@ -1,0 +1,48 @@
+const { connectToServer, close } = require("../../../server/db/conn");
+const demographics = require("../../../server/db/demographics");
+
+describe("db/demographics.js", () => {
+  beforeAll(() => connectToServer());
+  afterAll(() => close());
+
+  test("get() returns an array of demographic groups", () =>
+    demographics
+      .get()
+      .then((result) => expect(Array.isArray(result)).toBe(true)));
+
+  test("add() adds demographic data", async () => {
+    const demographicData = {
+      groups: ["Group1", "Group2"],
+      timestamp: new Date(),
+    };
+
+    await demographics.add(demographicData);
+
+    const result = await demographics.get();
+    const { groups, timestamp } = demographicData;
+    expect(result).toEqual(
+      expect.arrayContaining([expect.objectContaining({
+        groups, timestamp
+      })])
+    );
+  });
+
+  test("stats() returns expected counts", async () => {
+    const demographicData = {
+      // Group3 is unique to this test
+      groups: ["Group1", "Group2", "Group3"],
+      timestamp: new Date(),
+    };
+
+    await demographics.add(demographicData);
+
+    const result = await demographics.stats();
+    expect(result.count).toBeGreaterThan(1);
+    expect(result.groupCounts).toBeDefined();
+    // Group1 and Group2 are not unique, and might be more than 1 
+    expect(result.groupCounts.Group1).toBeGreaterThanOrEqual(1);
+    expect(result.groupCounts.Group2).toBeGreaterThanOrEqual(1);
+    // Group3 is unique to this test, and should be exactly 1
+    expect(result.groupCounts.Group3).toEqual(1);
+  });
+});


### PR DESCRIPTION
This is Part 1 of a 2 part fix for #126, adding the back-end data collection piece.  I'll push the front-end piece next, but it relies on this code being in place, so I want to get this merged first.

This change adds a new `demographics` collection to the database.  It is meant to keep user's personal information separate from the demographic info.  Every time a request comes in that includes at least 1 request for Rapid Tests (i.e., we won't bother if it's only masks being requested), we'll include anonymous demographic data about affected, vulnerable groups.

The collection's data schema looks like this:

```js
{
  _id: "61e86ee591676123aaab97d1",
  groups: ["People with low income", "Children/youth", ...],
  timestamp: "2022-01-19T20:04:52.611Z"
}
```

Any/all checkboxes for vulnerable groups will show up as an item in the `groups` field (i.e., Array).  I've also included a `.stats()` method for counting and reporting on these groups (currently there is no UI for this, we need to figure out how to do it...maybe a cli tool you can run on the server?).

I've also written unit tests for these changes.

There are no new dependencies for this change (i.e., no need for `npm install` on the server).