### PR TITLE
Include postal code in demographics data

### DIFF
--- a/server/db/demographics.js
+++ b/server/db/demographics.js
@@ -4,6 +4,7 @@ const dbo = require("./conn");
  * Demographics Schema:
  *
  * _id: "61e86ee591676123aaab97d1"
+ * postalCode: "M5W 1E6",
  * groups: ["People with low income", "Children/youth", ...] | ["None Selected"]
  * timestamp: "2022-01-19T20:04:52.611Z"
  *

--- a/server/routes/dbapi.js
+++ b/server/routes/dbapi.js
@@ -94,6 +94,7 @@ router.post("/api/mask_request_add", async (req, res, next) => {
     // Only bother with demographics data if we have tests requested
     if (req.body.testAmnt >= 1) {
       await demographics.add({
+        postalCode: req.body.postal,
         groups: req.body.demographics || ["None Selected"],
         timestamp: req.body.timestamp,
       });

--- a/test/server/db/demographics.test.js
+++ b/test/server/db/demographics.test.js
@@ -12,6 +12,7 @@ describe("db/demographics.js", () => {
 
   test("add() adds demographic data", async () => {
     const demographicData = {
+      postalCode: "M5W 1E6",
       groups: ["Group1", "Group2"],
       timestamp: new Date(),
     };
@@ -19,16 +20,17 @@ describe("db/demographics.js", () => {
     await demographics.add(demographicData);
 
     const result = await demographics.get();
-    const { groups, timestamp } = demographicData;
+    const { postalCode, groups, timestamp } = demographicData;
     expect(result).toEqual(
       expect.arrayContaining([expect.objectContaining({
-        groups, timestamp
+        postalCode, groups, timestamp
       })])
     );
   });
 
   test("stats() returns expected counts", async () => {
     const demographicData = {
+      postalCode: "M5W 1E7",
       // Group3 is unique to this test
       groups: ["Group1", "Group2", "Group3"],
       timestamp: new Date(),

--- a/test/server/routes/dbapi.test.js
+++ b/test/server/routes/dbapi.test.js
@@ -418,10 +418,11 @@ describe("dbapi", () => {
 
     // Make sure we get back the default demographics info
     const results = await demographics.get();
-    const { timestamp } = maskRequest;
+    const { timestamp, postalCode } = maskRequest;
     expect(results).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
+          postalCode,
           // The timestamp will be an ISO string vs. Date Object
           timestamp: timestamp.toISOString(),
         }),
@@ -459,10 +460,11 @@ describe("dbapi", () => {
 
     // Make sure we get back the default demographics info
     const results = await demographics.get();
-    const { timestamp } = maskRequest;
+    const { timestamp, postalCode } = maskRequest;
     expect(results).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
+          postalCode,
           groups: ["None Selected"],
           // The timestamp will be an ISO string vs. Date Object
           timestamp: timestamp.toISOString(),
@@ -505,6 +507,7 @@ describe("dbapi", () => {
     expect(results).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
+          postalCode: maskRequest.postalCode,
           groups: maskRequest.demographics,
           // The timestamp will be an ISO string vs. Date Object
           timestamp: maskRequest.timestamp.toISOString(),


### PR DESCRIPTION
Follow-up from https://github.com/EBSECan/donatemask/pull/133#issuecomment-1159170366, adding postal code info to the demographics data.

My reading of https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada/02_05_d_15/ is that this isn't considered PII, and should be OK.