### PR TITLE
Fix #126: add demographic info to request form

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -1,9 +1,3 @@
-export const MASK_SIZE = {
-  regular: "Regular-size Masks",
-  small: "Small-size Masks",
-  test: "COVID Test Boxes (5 per box)"
-};
-
 export const MASK_PRICE = 1.25;
 
 // We allow overriding these Stripe product links via environment variables.
@@ -22,3 +16,21 @@ export const STRIPE_LINKS = {
     refillPack: process.env.REACT_APP_STRIPE_MASK_LINK || "https://buy.stripe.com/5kAg0MgOt0U757G5kp",
   },
 };
+
+export const DEMOGRAPHIC_GROUPS = [
+  'Older adults',
+  'Caregivers',
+  'Persons with disabilities and/or health conditions',
+  'Members of the LGBTQ2SIA+ community',
+  'People experiencing or at risk for homelessness',
+  'People with low income',
+  'Children/youth',
+  'Indigenous Peoples',
+  'Racialized persons',
+  'Newcomers to Canada',
+  'People isolated socially or geographically',
+  'Essential workers',
+  'Other vulnerable populations not listed here',
+  'None of the above',
+  'Prefer not to say',
+];


### PR DESCRIPTION
Second part of the demographics change, fixes #126.

@emmaelaine and I used the following documents in our research and design, to determine the categories of vulnerable populations, and which wording to use. 

- https://www.canada.ca/content/dam/phac-aspc/documents/services/diseases-maladies/vulnerable-populations-covid-19/vulnerable-eng.pdf
- https://www.redcross.ca/crc/documents/How-We-Help/Current-Emergency-Responses/COVID-19/Emergency%20Support%20for%20Community%20Organizations/Definitions-Vulnerable-Populations_EN.pdf
- https://www.redcross.ca/crc/documents/How-We-Help/Current-Emergency-Responses/COVID-19/Stop-the-Spread-Application-Guidelines.pdf
- https://www.redcross.ca/how-we-help/current-emergency-responses/covid-19-%E2%80%93-novel-coronavirus/covid-19-rapid-tests-and-masks-for-community-organizations
- https://www.ohrc.on.ca/en/count-me-collecting-human-rights-based-data

Here's how it works.  The form starts out looking like this:

<img width="839" alt="Screen Shot 2022-06-17 at 4 29 57 PM" src="https://user-images.githubusercontent.com/427398/174397157-f3b7c058-d0c6-4b47-905a-221e94ac4628.png">

A user who enters some number of COVID Test Boxes (i.e., greater than 0) will get an additional section to fill out:

<img width="837" alt="Screen Shot 2022-06-17 at 4 31 06 PM" src="https://user-images.githubusercontent.com/427398/174397277-f2016dcc-e418-4262-adfe-0941cceeb738.png">

The user can choose any number of checkboxes, including those at the bottom which indicate they don't want to share information.  If none of the checkboxes are selected, we will use `"None Selected"` as our only value (i.e., we'll be able to see that they chose none).

On the back-end, I've already made changes in #133 and #134 to store the data as follows:

- postal code
- data and time
- list of group names (for example "Newcomers to Canada, Caregivers" or "None Selected" if the user didn't choose any checkboxes)
