### PR TITLE
Fix for breaking integration test with Request demographics change

### DIFF
--- a/src/components/RequestForm.js
+++ b/src/components/RequestForm.js
@@ -314,9 +314,9 @@ const RequestForm = () => {
         <Row>
           <Col md="4">
             <FormGroup>
-              <Label for="rat-amount">Number of Boxes (5 tests per-box)</Label>
+              <Label for="request-amount-test">Number of Boxes (5 tests per-box)</Label>
               <Input
-                id="rat-amount"
+                id="request-amount-test"
                 placeholder={`Number Requested`}
                 type="number"
                 min="0"


### PR DESCRIPTION
The changes in #135 broke the integration test for requests (see https://github.com/EBSECan/donatemask/runs/6942583498?check_suite_focus=true).  This fixes them by restoring the expected selector on the test count.