### PR TITLE
Always include demographic info for requests

### DIFF
--- a/server/routes/dbapi.js
+++ b/server/routes/dbapi.js
@@ -73,32 +73,31 @@ router.post("/api/donation_add", async (req, res, next) => {
 // Add mask request and demographic data, keeping the two separate
 router.post("/api/mask_request_add", async (req, res, next) => {
   try {
-    // Always add request data
-    await maskRequests.add({
-      requestorType: req.body.requestorType,
-      organizationName: req.body.organizationName,
-      organizationType: req.body.organizationType,
-      name: req.body.name,
-      address: req.body.address,
-      maskAmntRegular: req.body.maskAmntRegular,
-      maskAmntSmall: req.body.maskAmntSmall,
-      testAmnt: req.body.testAmnt,
-      postalCode: req.body.postal,
-      province: req.body.province,
-      email: req.body.email,
-      msg: req.body.msg,
-      requestFulfilled: false,
-      timestamp: req.body.timestamp,
-    });
-
-    // Only bother with demographics data if we have tests requested
-    if (req.body.testAmnt >= 1) {
-      await demographics.add({
+    // Record entries for requests and demographics separately
+    await Promise.all([
+      maskRequests.add({
+        requestorType: req.body.requestorType,
+        organizationName: req.body.organizationName,
+        organizationType: req.body.organizationType,
+        name: req.body.name,
+        address: req.body.address,
+        maskAmntRegular: req.body.maskAmntRegular,
+        maskAmntSmall: req.body.maskAmntSmall,
+        testAmnt: req.body.testAmnt,
+        postalCode: req.body.postal,
+        province: req.body.province,
+        email: req.body.email,
+        msg: req.body.msg,
+        requestFulfilled: false,
+        timestamp: req.body.timestamp,
+      }),
+      demographics.add({
         postalCode: req.body.postal,
         groups: req.body.demographics || ["None Selected"],
         timestamp: req.body.timestamp,
-      });
-    }
+      }),
+    ]);
+
     res.status(201).send("ok");
   } catch (err) {
     next(err);

--- a/src/components/RequestForm.js
+++ b/src/components/RequestForm.js
@@ -25,13 +25,15 @@ const buildAddress = (address, city, province, postalCode) =>
 // "None Selected" if left empty.
 const buildDemographicList = () => {
   const demographicList = [];
-  const selected = document.querySelectorAll('#demographic-groups input[type=checkbox]:checked');
-  selected.forEach(elem => demographicList.push(elem.value));
-  if(demographicList.length === 0) {
-    demographicList.push('None Selected');
+  const selected = document.querySelectorAll(
+    "#demographic-groups input[type=checkbox]:checked"
+  );
+  selected.forEach((elem) => demographicList.push(elem.value));
+  if (demographicList.length === 0) {
+    demographicList.push("None Selected");
   }
   return demographicList;
-}
+};
 
 const RequestForm = () => {
   const history = useHistory();
@@ -56,7 +58,7 @@ const RequestForm = () => {
 
   const onAmntChange = (event, type) => {
     let amount = parseInt(event.target.value, 10);
-    if(isNaN(amount)) {
+    if (isNaN(amount)) {
       amount = undefined;
     }
 
@@ -90,35 +92,28 @@ const RequestForm = () => {
       return false;
     }
 
-    const request = {
-      requestorType,
-      organizationName,
-      organizationType,
-      name,
-      email,
-      maskAmntRegular,
-      maskAmntSmall,
-      testAmnt,
-      address: buildAddress(address, city, province, postalCode),
-      province,
-      postal: postalCode,
-      msg,
-      timestamp: new Date(),
-    };
-
-    // If this request includes tests, add demographic info too
-    if (testAmnt >= 1) {
-      request.demographics = buildDemographicList();
-    }
-
     try {
-      // Adding Mask Request to DB
       const res = await fetch("/api/mask_request_add", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(request),
+        body: JSON.stringify({
+          requestorType,
+          organizationName,
+          organizationType,
+          name,
+          email,
+          maskAmntRegular,
+          maskAmntSmall,
+          testAmnt,
+          address: buildAddress(address, city, province, postalCode),
+          province,
+          postal: postalCode,
+          msg,
+          timestamp: new Date(),
+          demographics: buildDemographicList(),
+        }),
       });
       if (!res.ok) {
         throw new Error("Unable to add new mask request");
@@ -292,7 +287,7 @@ const RequestForm = () => {
                 placeholder={`Number Requested`}
                 type="number"
                 min="0"
-                onChange={(e) => onAmntChange(e, 'masks-regular')}
+                onChange={(e) => onAmntChange(e, "masks-regular")}
               />
             </FormGroup>
           </Col>
@@ -304,7 +299,7 @@ const RequestForm = () => {
                 placeholder={`Number Requested`}
                 type="number"
                 min="0"
-                onChange={(e) => onAmntChange(e, 'masks-small')}
+                onChange={(e) => onAmntChange(e, "masks-small")}
               />
             </FormGroup>
           </Col>
@@ -314,50 +309,53 @@ const RequestForm = () => {
         <Row>
           <Col md="4">
             <FormGroup>
-              <Label for="request-amount-test">Number of Boxes (5 tests per-box)</Label>
+              <Label for="request-amount-test">
+                Number of Boxes (5 tests per-box)
+              </Label>
               <Input
                 id="request-amount-test"
                 placeholder={`Number Requested`}
                 type="number"
                 min="0"
-                onChange={(e) => onAmntChange(e, 'tests')}
+                onChange={(e) => onAmntChange(e, "tests")}
               />
             </FormGroup>
           </Col>
         </Row>
 
-        {testAmnt >= 1 && (
-          <div className="mb-3">
-            <Row>
-              <Col>
-                <h4>Demographic Information</h4>
-                <p>
-                  Our rapid tests are supplied by the{" "}
-                  <strong>Canadian Red Cross</strong>, who have asked for data
-                  about the demographic groups receiving these tests. This data
-                  will be collected anonymously, and will not affect your request.
-                </p>
-                <p>
-                  <strong>Please select all boxes that apply</strong> to the
-                  request you are making for yourself or on behalf of another
-                  party:
-                </p>
-              </Col>
-            </Row>
-            <Row>
-              <Col>
-                <Container id="demographic-groups">
-                  {DEMOGRAPHIC_GROUPS.map((label) => (
-                    <FormGroup check key={label}>
-                      <Input id={`demographic-group-${label}`} type="checkbox" value={label} />{" "}
-                      <Label for={`demographic-group-${label}`} check>{label}</Label>
-                    </FormGroup>
-                  ))}
-                </Container>
-              </Col>
-            </Row>
-          </div>
-        )}
+        <h3 className="mt-2">Demographic Information</h3>
+        <Row>
+          <Col>
+            <p>
+              We receive support from the <strong>Canadian Red Cross</strong>,
+              who have asked for data about the demographic groups receiving
+              these items. This data will be collected anonymously, and will not
+              affect your request.
+            </p>
+            <p>
+              <strong>Please select all boxes that apply</strong> to the request
+              you are making for yourself or on behalf of another party:
+            </p>
+          </Col>
+        </Row>
+        <Row>
+          <Col>
+            <Container id="demographic-groups">
+              {DEMOGRAPHIC_GROUPS.map((label) => (
+                <FormGroup check key={label}>
+                  <Input
+                    id={`demographic-group-${label}`}
+                    type="checkbox"
+                    value={label}
+                  />{" "}
+                  <Label for={`demographic-group-${label}`} check>
+                    {label}
+                  </Label>
+                </FormGroup>
+              ))}
+            </Container>
+          </Col>
+        </Row>
 
         <Row>
           <Col md="12">

--- a/test/server/routes/dbapi.test.js
+++ b/test/server/routes/dbapi.test.js
@@ -388,48 +388,6 @@ describe("dbapi", () => {
     });
   });
 
-  test("A mask request with no tests should not add demographic data", async () => {
-    const maskRequest = {
-      requestorType: "organization",
-      organizationName: "Organization Name",
-      organizationType: "Organization Type",
-      name: "New Name",
-      address: "New Address",
-      maskAmntRegular: 2,
-      maskAmntSmall: 2,
-      testAmnt: 0,
-      postalCode: "M5W 1E7",
-      province: "Manitoba",
-      email: "email2@example.com",
-      msg: "New Message",
-      timestamp: new Date(),
-      // No demographics included
-    };
-
-    // Create a new mask request in the db
-    await request(app)
-      .post("/api/mask_request_add")
-      .send({
-        ...maskRequest,
-        // The route expects .postal to be sent, but db uses .postalCode
-        postal: maskRequest.postalCode,
-      })
-      .expect(201);
-
-    // Make sure we get back the default demographics info
-    const results = await demographics.get();
-    const { timestamp, postalCode } = maskRequest;
-    expect(results).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          postalCode,
-          // The timestamp will be an ISO string vs. Date Object
-          timestamp: timestamp.toISOString(),
-        }),
-      ])
-    );
-  });
-
   test("A mask request should add default demographic data", async () => {
     const maskRequest = {
       requestorType: "organization",


### PR DESCRIPTION
Based on discussions with @mekkim, the new demographic portion of the form should get included for all requests vs. only requests for rapid tests.  This makes that change to the back-end, front-end, and tests.

@mekkim it might make sense to update the back-end first and get that running in production before you do the front-end, or do them at the same time, since the changes depend on each other.

NOTE: there are no dependency changes in this.