### PR TITLE
Fix #149: disable request form submit while processing

### DIFF
--- a/src/components/RequestForm.js
+++ b/src/components/RequestForm.js
@@ -54,6 +54,7 @@ const RequestForm = () => {
 
   const [msg, setMsg] = useState("");
   const [error, setError] = useState();
+  const [submitting, setSubmitting] = useState(false);
   const [submitFailed, setSubmitFailed] = useState(false);
 
   const onAmntChange = (event, type) => {
@@ -93,6 +94,7 @@ const RequestForm = () => {
     }
 
     try {
+      setSubmitting(true);
       const res = await fetch("/api/mask_request_add", {
         method: "POST",
         headers: {
@@ -123,6 +125,8 @@ const RequestForm = () => {
     } catch (err) {
       console.log("Error submitting mask request", err);
       setSubmitFailed(true);
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -375,7 +379,7 @@ const RequestForm = () => {
             <FormGroup>
               <Button
                 id="request-submit"
-                disabled={!!error}
+                disabled={!!error || submitting}
                 color="success"
                 type="submit"
                 className="full-width"


### PR DESCRIPTION
Fixes #149.

This disables the submit button in the request form while the submission is being processed.  If it succeeds, we redirect (i.e., you can't re-submit on success); on failure, you can try again, which is fine, since we didn't process it the previous time.
