### PR TITLE
Constants for donations and GitHub url update and Store Price Change

### DIFF
--- a/src/components/Navbars/PageNavbar.js
+++ b/src/components/Navbars/PageNavbar.js
@@ -186,7 +186,7 @@ class PageNavbar extends React.Component {
                   <NavItem>
                     <NavLink
                       className="nav-link-icon"
-                      href="https://github.com/mekkim/donatemask"
+                      href="https://github.com/EBSECan/donatemask"
                       id="tooltip-navbar-github"
                       target="_blank"
                     >

--- a/src/const.js
+++ b/src/const.js
@@ -14,7 +14,7 @@ export const STRIPE_LINKS = {
     regular: process.env.REACT_APP_STRIPE_MASK_LINK || "https://buy.stripe.com/dR6cOA9m19qD0Rq5km",
     honeywell: process.env.REACT_APP_STRIPE_MASK_LINK || "https://buy.stripe.com/28o7ug0Pv8mzas0aEQ",
     respiratorKit: process.env.REACT_APP_STRIPE_MASK_LINK || "https://buy.stripe.com/5kAeWI9m1cCP57G28c",
-    refillPack: process.env.REACT_APP_STRIPE_MASK_LINK || "https://buy.stripe.com/5kAg0MgOt0U757G5kp",
+    refillPack: process.env.REACT_APP_STRIPE_MASK_LINK || "https://buy.stripe.com/00gbKwbu90U78jS7sN",
     dentecKit: process.env.REACT_APP_STRIPE_MASK_LINK || "https://buy.stripe.com/dR6eWIgOt0U77fOfZd",
     dentecRefillPack: process.env.REACT_APP_STRIPE_MASK_LINK || "https://buy.stripe.com/bIY6qc69P9qDbw4eVa",
     lanyard: process.env.REACT_APP_STRIPE_MASK_LINK || "https://buy.stripe.com/dR629WdChauHdEc5kB",
@@ -24,6 +24,33 @@ export const STRIPE_LINKS = {
     co2ModelD: process.env.REACT_APP_STRIPE_MASK_LINK || "https://buy.stripe.com/8wMeWI2XD5an43C3cq",
     aranet4: process.env.REACT_APP_STRIPE_MASK_LINK || "https://buy.stripe.com/cN29Co9m18mz1VufZb",
 	vitalight: process.env.REACT_APP_STRIPE_MASK_LINK || "https://buy.stripe.com/bIY7ugbu9byL0RqcN6",
+  }
+};
+
+// This is the number of "masks donated" for each store purchase. 
+// To get donation amount in dollars, multiply by MASK_PRICE above
+export const MASKS_DONATED_FROM_PURCHASE = {
+  ebook: {
+    $5: 4,
+    $10: 8,
+    $25: 20,
+    $50: 40,
+  },
+  mask: {
+    small: 25,
+    regular: 25,
+    honeywell: 20,
+    respiratorKit: 32,
+    refillPack: 32,
+    dentecKit: 30,
+    dentecRefillPack: 16,
+    lanyard: 4,
+  },
+  co2: {
+    co2ModelC: 32,
+    co2ModelD: 32,
+    aranet4: 25,
+	vitalight: 12,
   }
 };
 

--- a/src/views/Store.js
+++ b/src/views/Store.js
@@ -266,7 +266,7 @@ const BuyPage = () => {
             </>
           }
           dataSheetUrl={KitData}
-          price="$299.99"
+          price="$249.99"
           buyBtnId="buy-3m-refill"
           buyBtnOnClick={() => redirectTo(STRIPE_LINKS.mask.refillPack)}
           buyBtnText="Buy Pack"


### PR DESCRIPTION
1. Adds new constant array for amount of masks donated for each store purchase, to be used to auto insert donations into the database when a sale completes like what happens with cash donations (and save Mekki the manual entry!)
2. Updates github url to corporate url
3. Lowers price of 3M refill pack (that was too high) and updates store front end page and constant for Stripe payment link accordingly