### PR TITLE
Always use return positive ints from toInt()

### DIFF
--- a/server/util.js
+++ b/server/util.js
@@ -1,4 +1,6 @@
-const toInt = (value) => value|0;
+// Get a positive, integer value for a given number.
+// Non-numbers will return 0 (e.g., null)
+const toInt = (value) => Math.abs(value|0);
 
 // Allow overriding the web URL, but default to the public domain
 const webUrl = process.env.WEB_URL || 'https://donatemask.ca';

--- a/test/server/util.test.js
+++ b/test/server/util.test.js
@@ -9,5 +9,9 @@ describe("util", () => {
     test("toInt() should return an integer if value is a double", () => {
       expect(util.toInt(3.14)).toEqual(3);
     });
+
+    test("toInt() should always return a positive value", () => {
+      expect(util.toInt(-10)).toEqual(10);
+    });
   });
 });


### PR DESCRIPTION
I notice that there are some old records in the database where the number of masks is negative (e.g., `-10`).  This doesn't cause anything to blow up, but does reduce the totals by subtracting when we shouldn't.

This fixes things so our stats always produce positive integers when dealing with mask/test/etc counts.

NOTE: the new request form won't allow values lower than 0, so this is only to fix historic data errors.