### PR TITLE
Fix #156: add request priority drop-down

### DIFF
--- a/server/routes/dbapi.js
+++ b/server/routes/dbapi.js
@@ -76,6 +76,7 @@ router.post("/api/mask_request_add", async (req, res, next) => {
     // Record entries for requests and demographics separately
     await Promise.all([
       maskRequests.add({
+        priority: req.body.priority || 'normal',
         requestorType: req.body.requestorType,
         organizationName: req.body.organizationName,
         organizationType: req.body.organizationType,

--- a/src/components/RequestForm.js
+++ b/src/components/RequestForm.js
@@ -6,6 +6,7 @@ import {
   UncontrolledAlert,
   Button,
   FormGroup,
+  FormText,
   Form,
   Label,
   Input,
@@ -38,6 +39,7 @@ const buildDemographicList = () => {
 const RequestForm = () => {
   const history = useHistory();
 
+  const [requestPriority, setRequestPriority] = useState("normal");
   const [requestorType, setRequestorType] = useState("individual");
   const [organizationName, setOrganizationName] = useState("");
   const [organizationType, setOrganizationType] = useState("");
@@ -101,6 +103,7 @@ const RequestForm = () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
+          priority: requestPriority,
           requestorType,
           organizationName,
           organizationType,
@@ -134,7 +137,8 @@ const RequestForm = () => {
     <Container>
       <Form onSubmit={handleSubmit} id="request-form">
         <h3 className="display-3">Request Masks and COVID Tests</h3>
-        <p>Requests are free, and funded by charitable donations.</p>
+        <p>Requests are free, and funded by charitable donations. All requests are processed and fulfilled by volunteers.</p>
+
         <Row>
           <Col md="6">
             <FormGroup>
@@ -358,6 +362,24 @@ const RequestForm = () => {
                 </FormGroup>
               ))}
             </Container>
+          </Col>
+        </Row>
+        <Row className="mt-3">
+          <Col md="12">
+            <FormGroup>
+              <Label for="request-priority">Please help us prioritize your request. How urgent is your need?</Label>
+              <Input
+                id="request-priority"
+                type="select"
+                value={requestPriority}
+                onChange={(e) => setRequestPriority(e.target.value)}
+              >
+                <option value="low">Low Priority: fill order when possible, but no hurry (e.g., will not impact my immediate safety)</option>
+                <option value="normal">Normal Priority: nice to have masks/tests (e.g., won't be in danger if they're delayed a couple of weeks)</option>
+                <option value="high">High Priority: needed ASAP (e.g., upcoming high-risk event/appointment for which no protection is currently available)</option>
+              </Input>
+              <FormText><em>Disclaimer: while we can't promise shipments by a certain date, our volunteers use this info to help guide prioritization of requests.</em></FormText>
+            </FormGroup>
           </Col>
         </Row>
 

--- a/test/server/db/mask-requests.test.js
+++ b/test/server/db/mask-requests.test.js
@@ -12,6 +12,7 @@ describe("db/mask-requests.js", () => {
 
   test("add() adds a mask request", async () => {
     const maskRequest = {
+      priority: "normal",
       requestorType: "individual",
       organizationName: null,
       organizationType: null,
@@ -41,6 +42,7 @@ describe("db/mask-requests.js", () => {
 
   test("messages() gets recent messages", async () => {
     const maskRequest = {
+      priority: "normal",
       requestorType: "individual",
       organizationName: null,
       organizationType: null,

--- a/test/server/routes/dbapi.test.js
+++ b/test/server/routes/dbapi.test.js
@@ -47,6 +47,7 @@ describe("dbapi", () => {
       await request(app)
         .post("/api/mask_request_add")
         .send({
+          priority: "normal",
           requestorType: "individual",
           organizationName: null,
           organizationType: null,
@@ -75,6 +76,7 @@ describe("dbapi", () => {
 
     test("Messages should include most recent mask request", async () => {
       const maskRequest = {
+        priority: "normal",
         requestorType: "individual",
         organizationName: null,
         organizationType: null,
@@ -195,6 +197,7 @@ describe("dbapi", () => {
       await request(app)
         .post("/api/mask_request_add")
         .send({
+          priority: "normal",
           requestorType: "individual",
           organizationName: null,
           organizationType: null,
@@ -241,6 +244,7 @@ describe("dbapi", () => {
       await request(app)
         .post("/api/mask_request_add")
         .send({
+          priority: "normal",
           requestorType: "individual",
           organizationName: null,
           organizationType: null,
@@ -319,6 +323,7 @@ describe("dbapi", () => {
   describe("masks", () => {
     test("POST /api/mask_request_add should add a mask request and return 201", () => {
       const maskRequest = {
+        priority: "normal",
         requestorType: "individual",
         organizationName: null,
         organizationType: null,
@@ -344,6 +349,7 @@ describe("dbapi", () => {
 
     test("A mask request added should exist in returned results", async () => {
       const maskRequest = {
+        priority: "normal",
         requestorType: "organization",
         organizationName: "Organization Name",
         organizationType: "Organization Type",
@@ -390,6 +396,7 @@ describe("dbapi", () => {
 
   test("A mask request should add default demographic data", async () => {
     const maskRequest = {
+      priority: "normal",
       requestorType: "organization",
       organizationName: "Organization Name",
       organizationType: "Organization Type",
@@ -433,6 +440,7 @@ describe("dbapi", () => {
 
   test("A mask request with demographic data should get stored", async () => {
     const maskRequest = {
+      priority: "normal",
       requestorType: "organization",
       organizationName: "Organization Name",
       organizationType: "Organization Type",


### PR DESCRIPTION
Fixes #156

This adds a new section below the Demographics section of the form, allowing users to self-assign a priority for their request (high, normal, low).  The default is "normal":

<img width="837" alt="Screen Shot 2022-07-26 at 11 28 46 AM" src="https://user-images.githubusercontent.com/427398/181047276-aadfdad1-52c4-4a16-a8e3-c4f38aab3d7a.png">

The other options look like this:

<img width="844" alt="Screen Shot 2022-07-26 at 11 29 43 AM" src="https://user-images.githubusercontent.com/427398/181047526-798941a1-7316-4062-8a34-5663a17299b0.png">

The database will have `priority: "normal"` or `"high"`, `"low"`.