### PR TITLE
Add code to generate Request Report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ coverage/
 .DS_Store
 # Playwright test videos, traces
 test-results/
+# Generated report
+report.html

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       "install:clean": "rm -rf node_modules/ && rm -rf package-lock.json && npm install && npm start",
       "compile-sass": "node-sass src/assets/scss/argon-design-system-react.scss src/assets/css/argon-design-system-react.css",
       "minify-sass": "node-sass src/assets/scss/argon-design-system-react.scss src/assets/css/argon-design-system-react.min.css --output-style compressed",
-      "map-sass": "node-sass src/assets/scss/argon-design-system-react.scss src/assets/css/argon-design-system-react.css --source-map true"
+      "map-sass": "node-sass src/assets/scss/argon-design-system-react.scss src/assets/css/argon-design-system-react.css --source-map true",
+      "report": "node tools/report"
    },
    "browserslist": [
       ">0.2%",
@@ -78,8 +79,10 @@
       "concurrently": "^7.2.0",
       "gulp": "4.0.2",
       "gulp-append-prepend": "1.0.9",
+      "handlebars": "^4.7.7",
       "jest": "^28.0.3",
       "mongodb-memory-server": "^8.5.2",
+      "postal-code-helpers": "^1.0.12",
       "supertest": "^6.2.3"
    },
    "overrides": {

--- a/server/db/mask-requests.js
+++ b/server/db/mask-requests.js
@@ -24,14 +24,10 @@ module.exports.get = () => {
     .collection("maskrequests")
     .find({})
     .project({
-      requestorType: 0,
       organizationName: 0,
       organizationType: 0,
       name: 0,
       email: 0,
-      address: 0,
-      postal: 0,
-      province: 0,
     })
     .toArray();
 };

--- a/server/util.js
+++ b/server/util.js
@@ -1,13 +1,25 @@
 // Get a positive, integer value for a given number.
 // Non-numbers will return 0 (e.g., null)
-const toInt = (value) => Math.abs(value|0);
+const toInt = (value) => Math.abs(value | 0);
+
+// Turn a decimal value into a formatted percent
+const toPercent = (value) => {
+  if (value === 1) {
+    return "100%";
+  }
+  if (value === 0) {
+    return "0%";
+  }
+  return `${(value * 100).toFixed(2)}%`.replace(/.00%$/, '%');
+};
 
 // Allow overriding the web URL, but default to the public domain
-const webUrl = process.env.WEB_URL || 'https://donatemask.ca';
+const webUrl = process.env.WEB_URL || "https://donatemask.ca";
 
 // Allow overriding the Stripe Price ID for testing, but use the default otherwise
-const priceId = process.env.STRIPE_PRICE_ID || 'price_1KzoQkCOL3X1doeXOy2OfORX'
+const priceId = process.env.STRIPE_PRICE_ID || "price_1KzoQkCOL3X1doeXOy2OfORX";
 
 module.exports.toInt = toInt;
+module.exports.toPercent = toPercent;
 module.exports.priceId = priceId;
 module.exports.webUrl = webUrl;

--- a/test/server/util.test.js
+++ b/test/server/util.test.js
@@ -14,4 +14,22 @@ describe("util", () => {
       expect(util.toInt(-10)).toEqual(10);
     });
   });
+
+  describe('toPercent()', () => {
+    test('toPercent() should return 100% with no decimals for value of 1', () => {
+      expect(util.toPercent(1)).toEqual('100%');
+    });
+
+    test('toPercent() should return 0% with no decimals for value of 0', () => {
+      expect(util.toPercent(0)).toEqual('0%');
+    });
+
+    test('toPercent() should format a value with 2 decimal places into a percent', () => {
+      expect(util.toPercent(0.56781341)).toEqual('56.78%');
+    });
+
+    test('toPercent() should throw away decimal part if it is .00', () => {
+      expect(util.toPercent(0.5600000)).toEqual('56%');
+    });
+  });
 });

--- a/tools/report-template.hbs
+++ b/tools/report-template.hbs
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Donate A Mask: Request Report</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx"
+      crossorigin="anonymous"
+    />
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
+      crossorigin="anonymous"
+    ></script>
+  </head>
+  <body>
+    <main class="container pt-3">
+      <header class="my-5">
+        <img
+          class="rounded-circle border float-start me-2"
+          width="46"
+          height="46"
+          alt="Donate A Mask logo"
+          src="https://donatemask.ca/logos/logo-128x128.png"
+        />
+        <h1>Donate A Mask: Request Report</h1>
+        <p class="lead">Report generated on {{reportDate}}</p>
+      </header>
+
+      <section id="metric1" class="my-5">
+        <h2>1. Total Requests for Vulnerable Populations</h2>
+        <table class="table table-bordered">
+          <caption><strong>NOTE:</strong>
+            the collection of demographic data began on June 17, 2022. Thus,
+            <strong>Total Requests</strong>
+            in this table only reflects requests since that date.</caption>
+          <thead class="table-light">
+            <tr>
+              <th scope="col">Self-Identification</th>
+              <th scope="col"># of Requests</th>
+              <th scope="col">% of Total Requests</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Vulnerable - Yes</td>
+              <td>{{metric1.vulnerable.value}}</td>
+              <td>{{metric1.vulnerable.percent}}</td>
+            </tr>
+            <tr>
+              <td>Vulnerable - No</td>
+              <td>{{metric1.notVulnerable.value}}</td>
+              <td>{{metric1.notVulnerable.percent}}</td>
+            </tr>
+          </tbody>
+          <tfoot class="table-light">
+            <tr>
+              <th>Total Requests</th>
+              <th>{{metric1.total}}</th>
+              <th>&nbsp;</th>
+            </tr>
+          </tfoot>
+        </table>
+        <p>
+          <strong>Vulnerable - Yes</strong>: requests (masks and/or rapid tests)
+          made on behalf of persons self-identified as belonging to one or more
+          of the vulnerable groups listed on the “Demographic Information”
+          section of the request form.
+        </p>
+        <p>
+          <strong>Vulnerable - No</strong>: requests (masks and/or rapid tests)
+          made on behalf of persons not self-identified as belonging to one or
+          more of the vulnerable groups (i.e., selected
+          <em>Prefer not to say</em>, selected
+          <em>None of the above</em>, or made no selection).
+        </p>
+      </section>
+
+      <section id="metric2" class="my-5" style="page-break-after: always;">
+        <h2>2. Vulnerable Populations Served</h2>
+        <table class="table table-bordered">
+          <thead class="table-light">
+            <tr>
+              <th scope="col">Vulnerable Population Category</th>
+              <th scope="col">
+                # of Requests Involving this Category
+              </th>
+              <th scope="col">% of Total Requests</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each metric2.populations}}
+              <tr>
+                <td>{{this.name}}</td>
+                <td>{{this.value}}</td>
+                <td>{{this.percent}}</td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+        <p>
+          <strong>NOTE:</strong>
+          A single request may be made on behalf of persons self-identified as
+          belonging to more than one category. Thus,
+          <strong>Total Requests</strong>
+          does not equal the sum of all categories.
+          <strong>% of Total Requests</strong>
+          can be interpreted as the percent of total requests that involved
+          serving a specific category. For example,
+          <strong>{{metric2.populations.0.percent}}</strong>
+          of requests involved serving
+          <em>{{metric2.populations.0.name}}</em>.
+        </p>
+        <p>
+          The collection of demographic data began on June 17, 2022. Thus
+          <strong>% of Total Requests</strong>
+          has been calculated using total requests since that date.
+        </p>
+      </section>
+
+      <section id="metric3" class="my-5">
+        <h2>3. Requests by Region</h2>
+        <img
+          alt="Map of requests across Canada"
+          src="https://ebsecan.github.io/canada-map-requests/map.png"
+          width="100%"
+          class="img-fluid mb-3"
+        />
+        <p>
+          The following table shows the number of masks (regular and small size)
+          and number of boxes of rapid tests (5 tests per box) requested by
+          region, based on postal code. For each region, the total number of
+          items is shown, as well as the proportion of requests made for that
+          item in Canada.
+        </p>
+        <table class="table table-bordered">
+          <thead class="table-light">
+            <tr>
+              <th scope="col">&nbsp;</th>
+              <th scope="col" colspan="3" class="text-center">Masks</th>
+              <th scope="col" class="text-center">Rapid Tests</th>
+            </tr>
+            <tr>
+              <th scope="col">Region</th>
+              <th scope="col"># of Regular Masks</th>
+              <th scope="col"># of Small Masks</th>
+              <th scope="col">Total Masks</th>
+              <th scope="col"># of Boxes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each metric3.regions}}
+              <tr>
+                <td>{{this.name}}</td>
+                <td>
+                  {{this.regularMaskAmount.value}}
+                  ({{this.regularMaskAmount.percent}})
+                </td>
+                <td>
+                  {{this.smallMaskAmount.value}}
+                  ({{this.smallMaskAmount.percent}})
+                </td>
+                <td>
+                  {{this.maskAmountTotal.value}}
+                  ({{this.maskAmountTotal.percent}})
+                </td>
+                <td>{{this.testAmount.value}} ({{this.testAmount.percent}})</td>
+              </tr>
+            {{/each}}
+          </tbody>
+          <tfoot class="table-light">
+            <tr>
+              <th>Canada</th>
+              <th>{{metric3.Canada.regularMaskAmount.value}}</th>
+              <th>{{metric3.Canada.smallMaskAmount.value}}</th>
+              <th>{{metric3.Canada.maskAmountTotal.value}}</th>
+              <th>{{metric3.Canada.testAmount.value}}</th>
+            </tr>
+          </tfoot>
+        </table>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tools/report.js
+++ b/tools/report.js
@@ -1,0 +1,310 @@
+// Try to use server/config.env if present, otherwise the ATLAS_URI will need
+// to be specified manually before running.
+require("dotenv").config({ path: "server/config.env" });
+
+const fs = require("fs/promises");
+const Handlebars = require("handlebars");
+const postalCodeHelpers = require("postal-code-helpers");
+
+const { toInt, toPercent } = require("../server/util");
+const { connectToServer } = require("../server/db/conn");
+const demographics = require("../server/db/demographics");
+const requests = require("../server/db/mask-requests");
+
+// Format numbers for easier reading: 1024 -> "1,024"
+const formatNumber = (value) => new Intl.NumberFormat().format(value);
+
+// If we have a postalCode, use that. Otherwise try to
+// extract it from the address (not all requests have both).
+const extractPostalCode = (postalCode, address) => {
+  const cleanPostalCode = (postalCode) => {
+    if (!postalCode) {
+      return null;
+    }
+
+    let cleaned = postalCode.trim().toUpperCase().replace(/ /g, "");
+    // If it's not 6 in length now, it's likely not parsable, give up.
+    if (cleaned.length !== 6) {
+      return null;
+    }
+
+    return `${cleaned.slice(0, 3)} ${cleaned.slice(3)}`;
+  };
+
+  if (postalCode) {
+    return cleanPostalCode(postalCode);
+  }
+
+  const extracted = postalCodeHelpers.extract(address, "CA");
+  if (!(extracted && extracted.length)) {
+    return null;
+  }
+
+  let cleaned = extracted[0].trim().toUpperCase().replace(/ /g, "");
+  // If it's not 6 in length now, it's likely not parsable, give up.
+  if (cleaned.length !== 6) {
+    return null;
+  }
+
+  return `${cleaned.slice(0, 3)} ${cleaned.slice(3)}`;
+};
+
+// See https://www.canadapost-postescanada.ca/cpc/en/support/articles/addressing-guidelines/postal-codes.page
+const lookupRegion = (postalCode) => {
+  if (typeof postalCode !== "string") {
+    return null;
+  }
+
+  switch (postalCode[0].toUpperCase()) {
+    case "A":
+      return "Newfoundland and Labrador";
+    case "B":
+      return "Nova Scotia";
+    case "C":
+      return "Prince Edward Island";
+    case "E":
+      return "New Brunswick";
+    case "G":
+      return "Eastern Quebec";
+    case "H":
+      return "Metropolitan Montreal";
+    case "J":
+      return "Western Quebec";
+    case "K":
+      return "Eastern Ontario";
+    case "L":
+      return "Central Ontario";
+    case "M":
+      return "Metropolitan Toronto";
+    case "N":
+      return "Southwestern Ontario";
+    case "P":
+      return "Northern Ontario";
+    case "R":
+      return "Manitoba";
+    case "S":
+      return "Saskatchewan";
+    case "T":
+      return "Alberta";
+    case "V":
+      return "British Columbia";
+    case "X":
+      return "Northwest Territories/Nunavut";
+    case "Y":
+      return "Yukon";
+    default:
+      console.warn(`Unknown postal code region: ${postalCode}`);
+      return null;
+  }
+};
+
+/**
+ * 1. Requests from Vulnerable vs Not Vulnerable.  We define "Not Vulnerable"
+ * as Not Vulnerable = total requests - "None Selected", "None of the above", "Prefer not to say"
+ */
+const calculateVulnerableMetric = (stats) => {
+  const total = stats.count;
+  const groupCounts = stats.groupCounts;
+  const notVulnerable =
+    toInt(groupCounts["None of the above"]) +
+    toInt(groupCounts["Prefer not to say"]) +
+    toInt(groupCounts["None Selected"]);
+  const vulnerable = total - notVulnerable;
+
+  return {
+    total: formatNumber(total),
+    notVulnerable: {
+      value: formatNumber(notVulnerable),
+      percent: toPercent(notVulnerable / total),
+    },
+    vulnerable: {
+      value: formatNumber(vulnerable),
+      percent: toPercent(vulnerable / total),
+    },
+  };
+};
+
+/**
+ * 2. Vulnerable Populations
+ */
+const calculateVulnerablePopulationsMetric = (stats) => {
+  const total = stats.count;
+  const groupCounts = stats.groupCounts;
+
+  return {
+    total: formatNumber(total),
+    populations: Object.keys(groupCounts).map((group) => ({
+      name: group,
+      value: formatNumber(groupCounts[group]),
+      percent: toPercent(groupCounts[group] / total),
+    })),
+  };
+};
+
+/**
+ * 3. Request Data by Region
+ */
+const calculateRegionRequestsMetric = (data) => {
+  // Make sure every request has a proper postal code and province
+  data.forEach((r) => {
+    const postalCode = extractPostalCode(r.postalCode, r.address);
+    r.postalCode = postalCode;
+    r.region = lookupRegion(postalCode);
+  });
+  data = data.filter((r) => r.postalCode !== null && r.region !== null);
+
+  const calculateForRegion = (data, region) => {
+    if (region) {
+      data = data.filter((r) => r.region === region);
+    }
+
+    let regularMaskAmount = 0;
+    let smallMaskAmount = 0;
+    let testAmount = 0;
+
+    data.forEach((r) => {
+      regularMaskAmount += toInt(r.maskAmntRegular);
+      smallMaskAmount += toInt(r.maskAmntSmall);
+      testAmount += toInt(r.testAmnt);
+    });
+
+    return {
+      regularMaskAmount: {
+        value: regularMaskAmount,
+      },
+      smallMaskAmount: {
+        value: smallMaskAmount,
+      },
+      testAmount: {
+        value: testAmount,
+      },
+      maskAmountTotal: {
+        value: regularMaskAmount + smallMaskAmount,
+      },
+    };
+  };
+
+  // Calculate numbers for all of Canada
+  const canada = calculateForRegion(data);
+  const regions = [];
+
+  // Calculate for each region
+  [
+    "Newfoundland and Labrador",
+    "Nova Scotia",
+    "Prince Edward Island",
+    "New Brunswick",
+    "Eastern Quebec",
+    "Metropolitan Montreal",
+    "Western Quebec",
+    "Eastern Ontario",
+    "Central Ontario",
+    "Metropolitan Toronto",
+    "Southwestern Ontario",
+    "Northern Ontario",
+    "Manitoba",
+    "Saskatchewan",
+    "Alberta",
+    "British Columbia",
+    "Northwest Territories/Nunavut",
+    "Yukon",
+  ].forEach((region) => {
+    const regionData = calculateForRegion(data, region);
+
+    // Determine % of all Canada for this region, and format values for easier reading
+    regionData.regularMaskAmount.percent = toPercent(
+      regionData.regularMaskAmount.value / canada.regularMaskAmount.value
+    );
+    regionData.regularMaskAmount.value = formatNumber(
+      regionData.regularMaskAmount.value
+    );
+
+    regionData.smallMaskAmount.percent = toPercent(
+      regionData.smallMaskAmount.value / canada.smallMaskAmount.value
+    );
+    regionData.smallMaskAmount.value = formatNumber(
+      regionData.smallMaskAmount.value
+    );
+
+    regionData.maskAmountTotal.percent = toPercent(
+      regionData.maskAmountTotal.value / canada.maskAmountTotal.value
+    );
+    regionData.maskAmountTotal.value = formatNumber(
+      regionData.maskAmountTotal.value
+    );
+
+    regionData.testAmount.percent = toPercent(
+      regionData.testAmount.value / canada.testAmount.value
+    );
+    regionData.testAmount.value = formatNumber(regionData.testAmount.value);
+
+    regionData.name = region;
+
+    regions.push(regionData);
+  });
+
+  return {
+    Canada: {
+      regularMaskAmount: {
+        value: formatNumber(canada.regularMaskAmount.value),
+      },
+      smallMaskAmount: {
+        value: formatNumber(canada.smallMaskAmount.value),
+      },
+      testAmount: {
+        value: formatNumber(canada.testAmount.value),
+      },
+      maskAmountTotal: {
+        value: formatNumber(canada.maskAmountTotal.value),
+      },
+    },
+    regions,
+  };
+};
+
+const currentDate = () => {
+  const options = {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  };
+  const today = new Date();
+  return today.toLocaleDateString("en-CA", options);
+};
+
+const loadTemplate = () => fs.readFile("./tools/report-template.hbs", "utf-8");
+
+const generateReport = async (metrics) => {
+  const template = Handlebars.compile(await loadTemplate());
+  const html = template(metrics);
+  return fs.writeFile("./report.html", html);
+};
+
+const calculateMetrics = async () => {
+  await connectToServer();
+  const [demographicsStats, allRequests] = await Promise.all([
+    demographics.stats(),
+    requests.get(),
+  ]);
+
+  return {
+    reportDate: currentDate(),
+    metric1: calculateVulnerableMetric(demographicsStats),
+    metric2: calculateVulnerablePopulationsMetric(demographicsStats),
+    metric3: calculateRegionRequestsMetric(allRequests),
+  };
+};
+
+const start = async () => {
+  try {
+    const metrics = await calculateMetrics();
+    await generateReport(metrics);
+    process.exit(0);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+};
+
+start();


### PR DESCRIPTION
Emma and I have been working on creating an automated report for request/demographic data.  Emma has designed three major metrics, as well as the report structure, and I have programmed the code to populate it.  The metrics include:

1. Total Requests for Vulnerable Populations
2. Vulnerable Populations Served
3. Requests by Region

This report could be generated at any point to get up-to-date data, for example when talking to the Red Cross, other funding organizations, or the media.

The report produced is HTML, but I’ve attached an example PDF rendering (i.e., Print > Save as PDF), so you can see what it looks like:

[Donate A Mask_Request Report.pdf](https://github.com/EBSECan/donatemask/files/9311550/Donate.A.Mask_Request.Report.pdf)

To generate a report, you need to do the following:

1. make sure you have the dependencies installed: `npm install`
2. make sure you have a `server/config.env` file that includes the `ATALS_URI` database connection string (i.e., you need the database username/password to do this, since it talks to the db)
3. in the root directory run the `report` script: `npm run report`
4. the file `report.html` is your report.  Open in your browser to view.
