### PR TITLE
Add request purpose info to generated report, update Bootstrap, make printable

### DIFF
--- a/server/db/demographics.js
+++ b/server/db/demographics.js
@@ -27,16 +27,47 @@ module.exports.stats = async () => {
 
   // Go through all records, and all groups in those records,
   // and count how many times we encounter each one.
+  // Do the same for all request purpose data
   const groupCounts = {};
-  demographics.forEach(({ groups }) => {
+  const purposeCounts = {
+    total: 0,
+    purposes: {
+      Unspecified: 0,
+      "Return To School": 0,
+      "Return To Work": 0,
+    },
+  };
+
+  demographics.forEach(({ groups, purpose }) => {
     groups.forEach((group) => {
       groupCounts[group] = groupCounts[group] || 0;
       groupCounts[group] = groupCounts[group] + 1;
     });
+
+    if (purpose) {
+      // Keep a separate total for purpose counts, since we don't have as much historic data.
+      purposeCounts.total += 1;
+
+      let anySelected = false;
+      if (purpose.returnToSchool) {
+        purposeCounts.purposes["Return To School"] += 1;
+        anySelected = true;
+      }
+      if (purpose.returnToWork) {
+        purposeCounts.purposes["Return To Work"] += 1;
+        anySelected = true;
+      }
+
+      // Deal with the case of neither being selected
+      if (!anySelected) {
+        purposeCounts.purposes["Unspecified"] += 1;
+      }
+    }
   });
 
   return {
     count: demographics.length,
     groupCounts,
+    purposeCounts,
   };
 };

--- a/tools/report-template.hbs
+++ b/tools/report-template.hbs
@@ -5,14 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Donate A Mask: Request Report</title>
     <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css"
       rel="stylesheet"
-      integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css"
+      integrity="sha256-IUOUHAPazai08QFs7W4MbzTlwEWFo7z/4zw8YmxEiko="
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-print-css@1.0.1/css/bootstrap-print.min.css"
+      integrity="sha256-44dq5zhEEr5Mgw12MgOkjgYQKOsVL58o3b3dbuT+Bg8="
       crossorigin="anonymous"
     />
     <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"
+      integrity="sha256-h1OMS35Ij1pJ0S+Y1qBK/GHQDyankPMZVpeZrNQ062U="
       crossorigin="anonymous"
     ></script>
   </head>
@@ -79,7 +85,7 @@
         </p>
       </section>
 
-      <section id="metric2" class="my-5" style="page-break-after: always;">
+      <section id="metric2" class="my-5">
         <h2>2. Vulnerable Populations Served</h2>
         <table class="table table-bordered">
           <thead class="table-light">
@@ -122,14 +128,50 @@
       </section>
 
       <section id="metric3" class="my-5">
-        <h2>3. Requests by Region</h2>
+        <h2>3. Purpose of Request</h2>
+        <table class="table table-bordered">
+          <caption>
+            <strong>NOTE:</strong>
+            the collection of request purpose data began on August 30th, 2022.
+            Thus
+            <strong>% of Total Requests</strong>
+            has been calculated using total requests since that date.
+          </caption>
+          <thead class="table-light">
+            <tr>
+              <th scope="col">Purpose</th>
+              <th scope="col"># of Requests Involving this Purpose</th>
+              <th scope="col">% of Total Requests</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each metric3.purpose}}
+              <tr>
+                <td>{{this.name}}</td>
+                <td>{{this.value}}</td>
+                <td>{{this.percent}}</td>
+              </tr>
+            {{/each}}
+          </tbody>
+          <tfoot class="table-light">
+            <tr>
+              <th>Total Requests</th>
+              <th>{{metric3.total}}</th>
+              <th>&nbsp;</th>
+            </tr>
+          </tfoot>
+        </table>
+      </section>
+
+      <section id="metric4" class="my-5">
+        <h2>4. Requests by Region</h2>
         <img
           alt="Map of requests across Canada"
           src="https://ebsecan.github.io/canada-map-requests/map.png"
           width="100%"
           class="img-fluid mb-3"
         />
-        <p>
+        <p style="page-break-after: always;">
           The following table shows the number of masks (regular and small size)
           and number of boxes of rapid tests (5 tests per box) requested by
           region, based on postal code. For each region, the total number of
@@ -152,7 +194,7 @@
             </tr>
           </thead>
           <tbody>
-            {{#each metric3.regions}}
+            {{#each metric4.regions}}
               <tr>
                 <td>{{this.name}}</td>
                 <td>
@@ -174,10 +216,10 @@
           <tfoot class="table-light">
             <tr>
               <th>Canada</th>
-              <th>{{metric3.Canada.regularMaskAmount.value}}</th>
-              <th>{{metric3.Canada.smallMaskAmount.value}}</th>
-              <th>{{metric3.Canada.maskAmountTotal.value}}</th>
-              <th>{{metric3.Canada.testAmount.value}}</th>
+              <th>{{metric4.Canada.regularMaskAmount.value}}</th>
+              <th>{{metric4.Canada.smallMaskAmount.value}}</th>
+              <th>{{metric4.Canada.maskAmountTotal.value}}</th>
+              <th>{{metric4.Canada.testAmount.value}}</th>
             </tr>
           </tfoot>
         </table>

--- a/tools/report.js
+++ b/tools/report.js
@@ -142,7 +142,25 @@ const calculateVulnerablePopulationsMetric = (stats) => {
 };
 
 /**
- * 3. Request Data by Region
+ * 3. Purpose of Request. We don't have data for all time, just from Aug 30th.
+ */
+const calculateRequestPurposeMetric = (stats) => {
+  // The total for purpose data is less than the overall total
+  const total = stats.purposeCounts.total;
+  const purposes = stats.purposeCounts.purposes;
+
+  return {
+    total: formatNumber(total),
+    purpose: Object.keys(purposes).map((purpose) => ({
+      name: purpose,
+      value: formatNumber(purposes[purpose]),
+      percent: toPercent(purposes[purpose] / total),
+    })),
+  };
+};
+
+/**
+ * 4. Request Data by Region
  */
 const calculateRegionRequestsMetric = (data) => {
   // Make sure every request has a proper postal code and province
@@ -307,7 +325,8 @@ const calculateMetrics = async () => {
     reportDate: currentDate(),
     metric1: calculateVulnerableMetric(demographicsStats),
     metric2: calculateVulnerablePopulationsMetric(demographicsStats),
-    metric3: calculateRegionRequestsMetric(allRequests),
+    metric3: calculateRequestPurposeMetric(demographicsStats),
+    metric4: calculateRegionRequestsMetric(allRequests),
   };
 };
 


### PR DESCRIPTION
Fixes #191.

This updates the report logic to include the return-to-work and return-to-school stats we added in #179 on August 30th.  NOTE: this data is quite a bit smaller than the total number of requests, so I keep a separate total for purposes of calculating percentages.

I've also updated the version of Bootstrap and included a print CSS stylesheet, so we can print directly from the browser and have it look nice.

Here is the latest report:

[Donate A Mask Report Oct 26 2022.pdf](https://github.com/EBSECan/donatemask/files/9872243/Donate.A.Mask.Report.Oct.26.2022.pdf)
 